### PR TITLE
Fixing issue with JSON cache for variants pages

### DIFF
--- a/app/Page/VariantsPage.php
+++ b/app/Page/VariantsPage.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace App\Page;
 
 use Autodocs\DataFeed\JsonDataFeed;
-use Autodocs\Exception\NotFoundException;
 use Autodocs\Mark;
 use Autodocs\Page\ReferencePage;
 use Exception;
+use TypeError;
 
 class VariantsPage extends ReferencePage
 {
@@ -51,12 +51,12 @@ class VariantsPage extends ReferencePage
         $dataFeeds = $this->autodocs->dataFeeds;
         /** @var JsonDataFeed $dataFeed */
         foreach ($dataFeeds as $name => $dataFeed) {
-            if (str_starts_with($name, $this->image . '.latest')) {
+            if (str_starts_with($name, $this->image.'.latest')) {
                 list($imageName, $variantName, $extension) = explode('.', $name);
                 try {
-                    $dataFeed->loadFile($this->autodocs->config['cache_dir'] . '/' . $name);
+                    $dataFeed->loadFile($this->autodocs->config['cache_dir'].'/'.$name);
                     $variantsList[$variantName] = $dataFeed;
-                } catch (\TypeError $e) {
+                } catch (TypeError $e) {
                     //json might have issues. skip
                 }
             }

--- a/app/Page/VariantsPage.php
+++ b/app/Page/VariantsPage.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Page;
 
 use Autodocs\DataFeed\JsonDataFeed;
+use Autodocs\Exception\NotFoundException;
 use Autodocs\Mark;
 use Autodocs\Page\ReferencePage;
 use Exception;
@@ -48,15 +49,15 @@ class VariantsPage extends ReferencePage
     {
         $variantsList = [];
         $dataFeeds = $this->autodocs->dataFeeds;
-
         /** @var JsonDataFeed $dataFeed */
         foreach ($dataFeeds as $name => $dataFeed) {
-            $variantName = str_replace(".json", "", $name);
-            $variantName = str_replace($this->image.'-', "", $variantName);
-            if (in_array($variantName, self::$allowedTags)) {
-                $dataFeed->loadFile($this->autodocs->config['cache_dir'].'/'.$name);
-                if ($dataFeed->json) {
+            if (str_starts_with($name, $this->image . '.latest')) {
+                list($imageName, $variantName, $extension) = explode('.', $name);
+                try {
+                    $dataFeed->loadFile($this->autodocs->config['cache_dir'] . '/' . $name);
                     $variantsList[$variantName] = $dataFeed;
+                } catch (\TypeError $e) {
+                    //json might have issues. skip
                 }
             }
         }
@@ -85,7 +86,7 @@ class VariantsPage extends ReferencePage
         $packages = [];
         /** @var JsonDataFeed $variantFeed */
         foreach ($variants as $variant => $variantFeed) {
-            $config = $variantFeed->json;
+            $config = $variantFeed->json['predicate'];
             $headers[] = $variant;
             $columns[] = [
                 $this->getDefaultUser($config),

--- a/bin/getVariants.sh
+++ b/bin/getVariants.sh
@@ -12,7 +12,7 @@ for image in $(jq -r '.[].repo.name' ${OUTPUT_PATH}/images-tags.json); do
       cosign verify-attestation $(crane digest --full-ref --platform=linux/amd64 cgr.dev/chainguard/${image}:${tag}) \
         --certificate-identity="https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main" \
         --certificate-oidc-issuer="https://token.actions.githubusercontent.com" --type="https://apko.dev/image-configuration" \
-        | jq -r .payload | base64 -d | jq -r '.predicate' > ${OUTPUT_PATH}/${image}-${tag}.json
+        2>/dev/null | jq -rs '.[0].payload' | base64 -d > ${OUTPUT_PATH}/${image}.${tag}.json
     done
   done
 done

--- a/workdir/.gitignore
+++ b/workdir/.gitignore
@@ -1,0 +1,3 @@
+cache/*
+output/*
+sources/*

--- a/workdir/cache/.gitignore
+++ b/workdir/cache/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore


### PR DESCRIPTION
This PR adapts the pulling script and image build controller to work with metadata cache JSON that has multiple elements. 

TODO: update workflow in separate PR after a version bump, including new one-liner for pulling cache data.