### PR TITLE
Add some logic to find readmes for images like cert-manager-webhook

### DIFF
--- a/app/Page/OverviewPage.php
+++ b/app/Page/OverviewPage.php
@@ -34,6 +34,7 @@ class OverviewPage extends ReferencePage
 
     public function findReadme(string $image): string
     {
+        $dataFeeds = $this->autodocs->dataFeeds;
         $readme = "";
         $sources = $this->autodocs->config['images_sources'];
         foreach ($sources as $sourcePath) {
@@ -41,6 +42,13 @@ class OverviewPage extends ReferencePage
                 $readme = file_get_contents($sourcePath.'/'.$image.'/README.md');
                 break;
             }
+            # didn't find an image:readme 1:1 directory mapping, so look at image annotation for correct dir
+            $fName = $image.".latest.json";
+            $dataFeeds[$fName]->loadFile($this->autodocs->config['cache_dir'].'/'.$fName);
+            $image_source = $dataFeeds[$fName]->json["predicate"]["annotations"]["org.opencontainers.image.source"];
+            $image_source = explode("/", $image_source);
+            $image = end($image_source);
+            $readme = file_get_contents($sourcePath.'/'.$image.'/README.md');
         }
         return $readme;
     }

--- a/config/autodocs.php
+++ b/config/autodocs.php
@@ -20,7 +20,7 @@ return [
         'templates_dir' => envconfig('AUTODOCS_TEMPLATES', __DIR__.'/../templates'),
         'ignore_images' => config_unfurl(
             'AUTODOCS_IGNORE_IMAGES',
-            'alpine-base:k3s-images:sdk:spire:musl-dynamic:nri-kube-events:nri-kubernetes:nri-prometheus:gcc-musl'
+            'alpine-base:k3s-images:k3s-embedded:sdk:spire:musl-dynamic:nri-kube-events:nri-kubernetes:nri-prometheus:gcc-musl:source-controller'
         ),
         'changelog' => envconfig('AUTODOCS_CHANGELOG', __DIR__.'/../workdir/output'),
         'changelog_output' => envconfig('AUTODOCS_CHANGELOG_OUTPUT', __DIR__.'/../workdir/changelog.md')


### PR DESCRIPTION
I added a bit of logic to look for README.md files in directories based on an image's annotations. 

For example `cert-manager-webhook` looks like this:

```
cat workdir/cache/cert-manager-webhook.latest.json  |jq -r '.predicate .annotations ."org.opencontainers.image.source"'
https://github.com/chainguard-images/images/tree/main/images/cert-manager
```

So this code explodes that URL, uses the trailing `cert-manager` element and looks for a readme in the correct `workdir/sources/images/images/cert-manager/README.md` location for the image.

This isn't a substitute for pulling this data from the API or `chainctl img ls` longer term, but it should solve the problem of some of the missing readme files for today.