### PR TITLE
Update OverviewPage to only strip monopod markers

### DIFF
--- a/app/Page/OverviewPage.php
+++ b/app/Page/OverviewPage.php
@@ -27,7 +27,7 @@ class OverviewPage extends ReferencePage
         }
 
         $readme = str_ireplace("# {$readme}", "", $readme);
-        $readme = preg_replace('/<!--(.*)-->(.*)<!--(.*)-->/Uis', '', $readme);
+        $readme = preg_replace('/<!--monopod:start-->(.*)<!--monopod:end-->/Uis', '', $readme);
 
         $this->readme = $readme;
     }


### PR DESCRIPTION
This PR updates `app/Page/OverviewPage.php` to only strip out content between `<!--monopod:start>...<!--monopod:end-->` markers. Once this is merged, it will allow all the readme updates in https://github.com/chainguard-images/images/pull/1888 to render correctly. Without this using those new readmes there is no body content.