### PR TITLE
Update workflow to autodocs 1.3.0

### DIFF
--- a/.github/workflows/autodocs-images.yaml
+++ b/.github/workflows/autodocs-images.yaml
@@ -14,7 +14,7 @@ env:
   AUTODOCS_CHANGELOG: "${{ github.workspace }}/reference"
   AUTODOCS_CHANGELOG_OUTPUT: "${{ github.workspace }}/changelog.md"
   AUTODOCS_CHANGELOG_FILE: "${{ github.workspace }}/edu/autodocs/changelog.md"
-  AUTODOCS_IGNORE_IMAGES: "alpine-base:k3s-images:k3s-embedded:source-controller:sdk:spire:musl-dynamic:nri-kube-events:nri-kubernetes:nri-prometheus:gcc-musl"
+  AUTODOCS_IGNORE_IMAGES: "alpine-base:k3s-images:k3s-embedded:source-controller:sdk:spire:musl-dynamic:nri-kube-events:nri-kubernetes:nri-prometheus:gcc-musl:external-attacher:external-resizer:oidc-discovery-provider:kubernetes-dashboard-metrics-scraper:kustomize-controller:kyvernopre"
 jobs:
   main:
     permissions:
@@ -103,7 +103,7 @@ jobs:
       # Generate Docs
       ############################################################################################
       - name: Update the reference docs for Chainguard Images
-        uses: chainguard-dev/images-autodocs@1.2.2
+        uses: chainguard-dev/images-autodocs@1.3.0
         with:
           command: build images
 
@@ -151,7 +151,7 @@ jobs:
       ############################################################################################
       - name: "Send notification to Slack"
         if: ${{ steps.cpr.outputs.pull-request-number }}
-        uses: chainguard-dev/images-autodocs@1.2.2
+        uses: chainguard-dev/images-autodocs@1.3.0
         with:
           command: notify pullrequest
         env:


### PR DESCRIPTION
This will update the Autodocs workflow to the [latest release](https://github.com/chainguard-dev/images-autodocs/releases/tag/1.3.0) and add more images to the ignore list, following Mark's PRs [1183](https://github.com/chainguard-dev/edu/pull/1183) and [1187](https://github.com/chainguard-dev/edu/pull/1187).