### PR TITLE
Fix changelog cleanup

### DIFF
--- a/.github/workflows/autodocs-images.yaml
+++ b/.github/workflows/autodocs-images.yaml
@@ -70,11 +70,6 @@ jobs:
           cp "${{ env.AUTODOCS_CHANGELOG_FILE }}" "${{ env.AUTODOCS_CHANGELOG_OUTPUT }}" && \
           chmod 777 "${{ env.AUTODOCS_CHANGELOG_OUTPUT }}"
 
-      - name: Copy current reference docs to workdir (required for changelog)
-        run: |
-          cp -R "${{ github.workspace }}/edu/content/chainguard/chainguard-images/reference" "${{ github.workspace }}" && \
-          chmod -R 777 "${{ github.workspace }}/reference"
-
       ############################################################################################
       # Fetch Image Metadata
       ############################################################################################
@@ -103,7 +98,7 @@ jobs:
       # Generate Docs
       ############################################################################################
       - name: Update the reference docs for Chainguard Images
-        uses: chainguard-dev/images-autodocs@1.3.0
+        uses: chainguard-dev/images-autodocs@1.3.1
         with:
           command: build images
 
@@ -151,7 +146,7 @@ jobs:
       ############################################################################################
       - name: "Send notification to Slack"
         if: ${{ steps.cpr.outputs.pull-request-number }}
-        uses: chainguard-dev/images-autodocs@1.3.0
+        uses: chainguard-dev/images-autodocs@1.3.1
         with:
           command: notify pullrequest
         env:

--- a/app/ImageChangelog.php
+++ b/app/ImageChangelog.php
@@ -51,6 +51,7 @@ class ImageChangelog extends Changelog
 
             if ($previous[$index]['md5'] !== $file['md5']) {
                 $this->changedFiles[] = $file;
+                continue;
             }
 
             $this->unchangedFiles[] = $file;


### PR DESCRIPTION
this PR fixes a bug in the method that identifies which files were not changed and should be removed.

it also updates the workflow to remove a step that is not necessary anymore, as well as bumping the version to the next release that is coming when I get this merged.