### PR TITLE
 Update Autodocs to consume README from chainctl

### DIFF
--- a/.github/workflows/autodocs-images.yaml
+++ b/.github/workflows/autodocs-images.yaml
@@ -7,14 +7,13 @@ on:
   workflow_dispatch:
 
 env:
-  AUTODOCS_SOURCES: "${{ github.workspace }}/images/images"
   AUTODOCS_OUTPUT: "${{ github.workspace }}/reference"
   AUTODOCS_CACHE: "${{ github.workspace }}/cache"
   AUTODOCS_TEMPLATES: "${{ github.workspace }}/autodocs/templates"
   AUTODOCS_CHANGELOG: "${{ github.workspace }}/edu/content/chainguard/chainguard-images/reference"
   AUTODOCS_CHANGELOG_OUTPUT: "${{ github.workspace }}/changelog.md"
   AUTODOCS_CHANGELOG_FILE: "${{ github.workspace }}/edu/autodocs/changelog.md"
-  AUTODOCS_IGNORE_IMAGES: "alpine-base:k3s-images:k3s-embedded:source-controller:sdk:spire:musl-dynamic:nri-kube-events:nri-kubernetes:nri-prometheus:gcc-musl:external-attacher:external-resizer:oidc-discovery-provider:kubernetes-dashboard-metrics-scraper:kustomize-controller:kyvernopre"
+  AUTODOCS_IGNORE_IMAGES: "alpine-base:k3s-images:k3s-embedded:source-controller:sdk:spire:musl-dynamic:nri-kube-events:nri-kubernetes:nri-prometheus:gcc-musl:external-attacher:external-resizer:oidc-discovery-provider:kubernetes-dashboard-metrics-scraper:kustomize-controller:kyvernopre:alpine-base:curl-dev"
 jobs:
   main:
     permissions:
@@ -36,13 +35,7 @@ jobs:
           repository: chainguard-dev/edu
           path: edu
 
-      - name: Checkout Images Monorepo
-        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
-        with:
-          repository: chainguard-images/images
-          path: images
-
-      - name: Checkout Autodocs repo for up-to-date Templates
+      - name: Checkout Autodocs repo
         uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
         with:
           repository: chainguard-dev/images-autodocs
@@ -98,7 +91,7 @@ jobs:
       # Generate Docs
       ############################################################################################
       - name: Update the reference docs for Chainguard Images
-        uses: chainguard-dev/images-autodocs@1.3.2
+        uses: chainguard-dev/images-autodocs@1.3.3
         with:
           command: build images
 
@@ -146,7 +139,7 @@ jobs:
       ############################################################################################
       - name: "Send notification to Slack"
         if: ${{ steps.cpr.outputs.pull-request-number }}
-        uses: chainguard-dev/images-autodocs@1.3.2
+        uses: chainguard-dev/images-autodocs@1.3.3
         with:
           command: notify pullrequest
         env:

--- a/app/Command/Build/ImagesController.php
+++ b/app/Command/Build/ImagesController.php
@@ -21,12 +21,13 @@ class ImagesController extends CommandController
         $changelog = new ImageChangelog($autodocs->config['output']);
         $changelog->capture();
 
-        //get list of images
-        $imagesList = new JsonDataFeed();
         try {
-            $imagesList->loadFile($autodocs->config['cache_dir'].'/'.$autodocs->config['cache_images_file']);
-        } catch (NotFoundException $exception) {
-            $this->error("Cache file not found: ".$autodocs->config['cache_dir'].'/'.$autodocs->config['cache_images_file']);
+            $imagesList = $autodocs->getDataFeed($autodocs->config['cache_images_file']);
+        } catch (\Exception $exception) {
+            $this->error("Error: " . $exception->getMessage());
+            return;
+        } catch (\TypeError $error) {
+            $this->error("Error: " . $error->getMessage());
             return;
         }
 

--- a/app/Command/Build/ImagesController.php
+++ b/app/Command/Build/ImagesController.php
@@ -6,10 +6,10 @@ namespace App\Command\Build;
 
 use App\ImageChangelog;
 use App\Page\ChangelogPage;
-use Autodocs\DataFeed\JsonDataFeed;
-use Autodocs\Exception\NotFoundException;
 use autodocs\Service\AutodocsService;
 use Minicli\Command\CommandController;
+use Exception;
+use TypeError;
 
 class ImagesController extends CommandController
 {
@@ -23,11 +23,11 @@ class ImagesController extends CommandController
 
         try {
             $imagesList = $autodocs->getDataFeed($autodocs->config['cache_images_file']);
-        } catch (\Exception $exception) {
-            $this->error("Error: " . $exception->getMessage());
+        } catch (Exception $exception) {
+            $this->error("Error: ".$exception->getMessage());
             return;
-        } catch (\TypeError $error) {
-            $this->error("Error: " . $error->getMessage());
+        } catch (TypeError $error) {
+            $this->error("Error: ".$error->getMessage());
             return;
         }
 

--- a/app/Page/OverviewPage.php
+++ b/app/Page/OverviewPage.php
@@ -10,59 +10,39 @@ use Minicli\FileNotFoundException;
 class OverviewPage extends ReferencePage
 {
     public string $image;
-    public string $readme;
+
+    public function loadData(array $parameters = []): void
+    {
+        $this->image = $parameters['image'];
+    }
 
     /**
      * @throws FileNotFoundException
      */
-    public function loadData(array $parameters = []): void
-    {
-        $this->image = $parameters['image'];
-        $readme = $this->findReadme($this->image);
-
-        if ("" === $readme) {
-            $readme = $this->autodocs->stencil->applyTemplate('image_overview_fallback', [
-                'image' => $this->image
-            ]);
-        }
-
-        $readme = str_ireplace("# {$readme}", "", $readme);
-        $readme = preg_replace('/<!--monopod:start-->(.*)<!--monopod:end-->/Uis', '', $readme);
-
-        $this->readme = $readme;
-    }
-
     public function findReadme(string $image): string
     {
-        $dataFeeds = $this->autodocs->dataFeeds;
-        $readme = "";
-        $sources = $this->autodocs->config['images_sources'];
-        foreach ($sources as $sourcePath) {
-            if (is_dir($sourcePath.'/'.$image)) {
-                $readme = file_get_contents($sourcePath.'/'.$image.'/README.md');
-                break;
-            }
-            # didn't find an image:readme 1:1 directory mapping, so look at image annotation for correct dir
-            $fName = $image.".latest.json";
-            if ( ! array_key_exists($fName, $dataFeeds)) {
-                continue;
-            }
+        $imagesList = $this->autodocs->getDataFeed($this->autodocs->config['cache_images_file']);
+        foreach ($imagesList->json as $imageInfo) {
+            if ($imageInfo['repo']['name'] === $image) {
+                if (array_key_exists('readme', $imageInfo['repo'])) {
+                    return $imageInfo['repo']['readme'];
+                }
 
-            $dataFeeds[$fName]->loadFile($this->autodocs->config['cache_dir'].'/'.$fName);
-            if (empty($dataFeeds[$fName]->json) || ! key_exists('predicate', $dataFeeds[$fName]->json)) {
-                continue;
-            }
-
-            $image_source = $dataFeeds[$fName]->json["predicate"]["annotations"]["org.opencontainers.image.source"];
-            $image_source = explode("/", $image_source);
-            $image = end($image_source);
-
-            $parentReadme = $sourcePath.'/'.$image.'/README.md';
-            if (is_file($parentReadme)) {
-                $readme = file_get_contents($parentReadme);
+                //readme not defined, try to find from annotation
+                $imageMeta = $this->autodocs->getDataFeed("$image.latest.json");
+                $image_source = $imageMeta->json["predicate"]["annotations"]["org.opencontainers.image.source"];
+                $image_source = explode("/", $image_source);
+                $referenceImage = end($image_source);
+                if ($referenceImage != $image) {
+                    $this->findReadme($referenceImage);
+                }
             }
         }
-        return $readme;
+
+        //no readme found, return fallback template
+        return $this->autodocs->stencil->applyTemplate('image_overview_fallback', [
+            'image' => $this->image
+        ]);
     }
 
     public function getName(): string
@@ -80,9 +60,14 @@ class OverviewPage extends ReferencePage
      */
     public function getContent(): string
     {
+        $readme = $this->findReadme($this->image);
+
+        $readme = str_ireplace("# {$readme}", "", $readme);
+        $readme = preg_replace('/<!--monopod:start-->(.*)<!--monopod:end-->/Uis', '', $readme);
+
         return $this->autodocs->stencil->applyTemplate('image_overview', [
             'title' => $this->image,
-            'content' => $this->readme
+            'content' => $readme
         ]);
     }
 }

--- a/app/Page/OverviewPage.php
+++ b/app/Page/OverviewPage.php
@@ -29,11 +29,11 @@ class OverviewPage extends ReferencePage
                 }
 
                 //readme not defined, try to find from annotation
-                $imageMeta = $this->autodocs->getDataFeed("$image.latest.json");
+                $imageMeta = $this->autodocs->getDataFeed("{$image}.latest.json");
                 $image_source = $imageMeta->json["predicate"]["annotations"]["org.opencontainers.image.source"];
                 $image_source = explode("/", $image_source);
                 $referenceImage = end($image_source);
-                if ($referenceImage != $image) {
+                if ($referenceImage !== $image) {
                     $this->findReadme($referenceImage);
                 }
             }

--- a/config/autodocs.php
+++ b/config/autodocs.php
@@ -9,11 +9,6 @@ use App\Page\VariantsPage;
 
 return [
     'autodocs' => [
-        // Where to look for image READMES
-        'images_sources' => config_unfurl(
-            'AUTODOCS_SOURCES',
-            __DIR__.'/../workdir/sources/images/images'
-        ),
         // Pages to Build
         'pages' => [
             OverviewPage::class,
@@ -32,7 +27,7 @@ return [
         // String containing list of images to skip building docs for, separated by a colon
         'ignore_images' => config_unfurl(
             'AUTODOCS_IGNORE_IMAGES',
-            'alpine-base:k3s-images:k3s-embedded:sdk:spire:musl-dynamic:nri-kube-events:nri-kubernetes:nri-prometheus:gcc-musl:source-controller'
+            'alpine-base:k3s-images:k3s-embedded:sdk:spire:musl-dynamic:nri-kube-events:nri-kubernetes:nri-prometheus:gcc-musl:source-controller:curl-dev:alpine-base'
         ),
         // Original files that should be used as base for changelog comparison
         'changelog' => envconfig('AUTODOCS_CHANGELOG', __DIR__.'/../workdir/original'),

--- a/workdir/sources/.gitignore
+++ b/workdir/sources/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore


### PR DESCRIPTION
This PR updates Autodocs to consume image READMEs directly from chainctl JSON feeds. It also updates the workflow to remove steps that used to check out the images repository into the workdir, since that is no longer necessary. I also pre-bumped the action version in the workflow and once this is merged I will release 1.3.3 .