### PR TITLE
Production Images Update

### DIFF
--- a/app/Command/Build/DatafeedsController.php
+++ b/app/Command/Build/DatafeedsController.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command\Build;
+
+use App\ImageCollection;
+use Autodocs\DataFeed\JsonDataFeed;
+use Autodocs\Exception\NotFoundException;
+use autodocs\Service\AutodocsService;
+use Minicli\Command\CommandController;
+use Exception;
+use TypeError;
+
+class DatafeedsController extends CommandController
+{
+    /**
+     * @throws NotFoundException
+     */
+    public function handle(): void
+    {
+        /** @var AutodocsService $autodocs */
+        $autodocs = $this->getApp()->autodocs;
+
+        try {
+            $imagesDevList = $autodocs->getDataFeed('images-tags-dev.json');
+            $imagesProdList = $autodocs->getDataFeed('images-tags-prod.json');
+        } catch (Exception $exception) {
+            $this->error("Error: ".$exception->getMessage());
+            return;
+        } catch (TypeError $error) {
+            $this->error("Error: ".$error->getMessage());
+            return;
+        }
+
+        $cacheDev = $this->getApp()->autodocs->config['cache_dir'] . '/images-dev';
+        $cacheProd = $this->getApp()->autodocs->config['cache_dir'] . '/images-prod';
+
+        $images = new ImageCollection();
+        foreach ($imagesDevList->json as $imageInfo) {
+            $image = $images->get($imageInfo['repo']['name'], true);
+            $image->tagsDev = $imageInfo['tags'];
+            if (array_key_exists('readme',  $imageInfo['repo'])){
+                $image->readmeProd = $imageInfo['repo']['readme'];
+            }
+            $image->variantsDev = $this->getImageConfigs($image->getName(), $cacheDev);
+            $images->add($image);
+            $autodocs->storage->saveFile($autodocs->config['cache_dir'] . '/datafeeds/' . $image->name . ".json", $image->getJson());
+        }
+
+
+        foreach ($imagesProdList->json as $imageInfo) {
+            $image = $images->get($imageInfo['repo']['name'], true);
+            $image->tagsProd = $imageInfo['tags'];
+            if (array_key_exists('readme',  $imageInfo['repo'])){
+                $image->readmeProd = $imageInfo['repo']['readme'];
+            }
+            $image->variantsProd = $this->getImageConfigs($image->getName(), $cacheProd);
+            $images->add($image);
+            $autodocs->storage->saveFile($autodocs->config['cache_dir'] . '/datafeeds/' . $image->name . ".json", $image->getJson());
+        }
+
+        $this->success("Finished building image Datafeeds based on cached data.");
+    }
+
+    /**
+     * @throws NotFoundException
+     */
+    public function getImageConfigs(string $image, string $cachePath): array
+    {
+        $variantsList = [];
+
+        foreach (glob($cachePath . '/*.json') as $imageConfig) {
+            if (str_starts_with(basename($imageConfig), $image.'.latest')) {
+
+                list($imageName, $variantName, $extension) = explode('.', basename($imageConfig));
+                try {
+                    $dataFeed = new JsonDataFeed();
+                    $dataFeed->loadFile($imageConfig);
+                    $variantsList[$variantName] = $dataFeed->json;
+                } catch (TypeError $e) {
+                    //json might have issues. skip
+                }
+            }
+        }
+
+        return $variantsList;
+    }
+}

--- a/app/Command/Build/DatafeedsController.php
+++ b/app/Command/Build/DatafeedsController.php
@@ -33,30 +33,30 @@ class DatafeedsController extends CommandController
             return;
         }
 
-        $cacheDev = $this->getApp()->autodocs->config['cache_dir'] . '/images-dev';
-        $cacheProd = $this->getApp()->autodocs->config['cache_dir'] . '/images-prod';
+        $cacheDev = $this->getApp()->autodocs->config['cache_dir'].'/images-dev';
+        $cacheProd = $this->getApp()->autodocs->config['cache_dir'].'/images-prod';
 
         $images = new ImageCollection();
         //all dev images are in the prod list, the opposite is not true. use prod images as source of truth
         foreach ($imagesProdList->json as $imageInfo) {
             $image = $images->get($imageInfo['repo']['name'], true);
             $image->tagsProd = $imageInfo['tags'];
-            if (array_key_exists('readme',  $imageInfo['repo'])){
+            if (array_key_exists('readme', $imageInfo['repo'])) {
                 $image->readmeProd = $imageInfo['repo']['readme'];
             }
             $image->variants = $this->getImageConfigs($image->getName(), $cacheProd);
             $images->add($image);
-            $autodocs->storage->saveFile($autodocs->config['cache_dir'] . '/datafeeds/' . $image->name . ".json", $image->getJson());
+            $autodocs->storage->saveFile($autodocs->config['cache_dir'].'/datafeeds/'.$image->name.".json", $image->getJson());
         }
         //get complimentary information about public tags, readme
         foreach ($imagesDevList->json as $imageInfo) {
             $image = $images->get($imageInfo['repo']['name'], true);
             $image->tagsDev = $imageInfo['tags'];
-            if (array_key_exists('readme',  $imageInfo['repo'])){
+            if (array_key_exists('readme', $imageInfo['repo'])) {
                 $image->readmeDev = $imageInfo['repo']['readme'];
             }
             $images->add($image);
-            $autodocs->storage->saveFile($autodocs->config['cache_dir'] . '/datafeeds/' . $image->name . ".json", $image->getJson());
+            $autodocs->storage->saveFile($autodocs->config['cache_dir'].'/datafeeds/'.$image->name.".json", $image->getJson());
         }
 
         $this->success("Finished building image Datafeeds based on cached data.");
@@ -69,7 +69,7 @@ class DatafeedsController extends CommandController
     {
         $variantsList = [];
 
-        foreach (glob($cachePath . '/*.json') as $imageConfig) {
+        foreach (glob($cachePath.'/*.json') as $imageConfig) {
             if (str_starts_with(basename($imageConfig), $image.'.latest')) {
 
                 list($imageName, $variantName, $extension) = explode('.', basename($imageConfig));

--- a/app/Command/Build/DatafeedsController.php
+++ b/app/Command/Build/DatafeedsController.php
@@ -37,25 +37,24 @@ class DatafeedsController extends CommandController
         $cacheProd = $this->getApp()->autodocs->config['cache_dir'] . '/images-prod';
 
         $images = new ImageCollection();
-        foreach ($imagesDevList->json as $imageInfo) {
-            $image = $images->get($imageInfo['repo']['name'], true);
-            $image->tagsDev = $imageInfo['tags'];
-            if (array_key_exists('readme',  $imageInfo['repo'])){
-                $image->readmeDev = $imageInfo['repo']['readme'];
-            }
-            $image->variantsDev = $this->getImageConfigs($image->getName(), $cacheDev);
-            $images->add($image);
-            $autodocs->storage->saveFile($autodocs->config['cache_dir'] . '/datafeeds/' . $image->name . ".json", $image->getJson());
-        }
-
-
+        //all dev images are in the prod list, the opposite is not true. use prod images as source of truth
         foreach ($imagesProdList->json as $imageInfo) {
             $image = $images->get($imageInfo['repo']['name'], true);
             $image->tagsProd = $imageInfo['tags'];
             if (array_key_exists('readme',  $imageInfo['repo'])){
                 $image->readmeProd = $imageInfo['repo']['readme'];
             }
-            $image->variantsProd = $this->getImageConfigs($image->getName(), $cacheProd);
+            $image->variants = $this->getImageConfigs($image->getName(), $cacheProd);
+            $images->add($image);
+            $autodocs->storage->saveFile($autodocs->config['cache_dir'] . '/datafeeds/' . $image->name . ".json", $image->getJson());
+        }
+        //get complimentary information about public tags, readme
+        foreach ($imagesDevList->json as $imageInfo) {
+            $image = $images->get($imageInfo['repo']['name'], true);
+            $image->tagsDev = $imageInfo['tags'];
+            if (array_key_exists('readme',  $imageInfo['repo'])){
+                $image->readmeDev = $imageInfo['repo']['readme'];
+            }
             $images->add($image);
             $autodocs->storage->saveFile($autodocs->config['cache_dir'] . '/datafeeds/' . $image->name . ".json", $image->getJson());
         }

--- a/app/Command/Build/DatafeedsController.php
+++ b/app/Command/Build/DatafeedsController.php
@@ -41,7 +41,7 @@ class DatafeedsController extends CommandController
             $image = $images->get($imageInfo['repo']['name'], true);
             $image->tagsDev = $imageInfo['tags'];
             if (array_key_exists('readme',  $imageInfo['repo'])){
-                $image->readmeProd = $imageInfo['repo']['readme'];
+                $image->readmeDev = $imageInfo['repo']['readme'];
             }
             $image->variantsDev = $this->getImageConfigs($image->getName(), $cacheDev);
             $images->add($image);

--- a/app/Command/Build/ImagesController.php
+++ b/app/Command/Build/ImagesController.php
@@ -6,6 +6,8 @@ namespace App\Command\Build;
 
 use App\ImageChangelog;
 use App\Page\ChangelogPage;
+use Autodocs\DataFeed\JsonDataFeed;
+use Autodocs\Exception\NotFoundException;
 use autodocs\Service\AutodocsService;
 use Minicli\Command\CommandController;
 use Exception;
@@ -13,6 +15,9 @@ use TypeError;
 
 class ImagesController extends CommandController
 {
+    /**
+     * @throws NotFoundException
+     */
     public function handle(): void
     {
         /** @var AutodocsService $autodocs */
@@ -21,6 +26,7 @@ class ImagesController extends CommandController
         $changelog = new ImageChangelog($autodocs->config['output']);
         $changelog->capture();
 
+        /*
         try {
             $imagesList = $autodocs->getDataFeed($autodocs->config['cache_images_file']);
         } catch (Exception $exception) {
@@ -29,13 +35,16 @@ class ImagesController extends CommandController
         } catch (TypeError $error) {
             $this->error("Error: ".$error->getMessage());
             return;
-        }
+        }*/
+
 
         if ($this->hasParam('image')) {
             $this->buildDocsForImage($this->getParam('image'));
         } else {
-            foreach ($imagesList->json as $image) {
-                $imageName = $image['repo']['name'];
+            foreach (glob($autodocs->config['cache_dir'] . '/datafeeds/*.json') as $imageCache) {
+                $dataFeed = new JsonDataFeed();
+                $dataFeed->loadFile($imageCache);
+                $imageName = $dataFeed->json['name'];
                 $this->buildDocsForImage($imageName);
             }
         }

--- a/app/Command/Build/ImagesController.php
+++ b/app/Command/Build/ImagesController.php
@@ -41,7 +41,7 @@ class ImagesController extends CommandController
         if ($this->hasParam('image')) {
             $this->buildDocsForImage($this->getParam('image'));
         } else {
-            foreach (glob($autodocs->config['cache_dir'] . '/datafeeds/*.json') as $imageCache) {
+            foreach (glob($autodocs->config['cache_dir'].'/datafeeds/*.json') as $imageCache) {
                 $dataFeed = new JsonDataFeed();
                 $dataFeed->loadFile($imageCache);
                 $imageName = $dataFeed->json['name'];

--- a/app/Image.php
+++ b/app/Image.php
@@ -2,15 +2,18 @@
 
 namespace App;
 
+use Autodocs\DataFeed\JsonDataFeed;
+use Autodocs\Exception\NotFoundException;
+
 class Image
 {
     public string $name;
 
     public string $readmeDev = "";
-    public array $tagsDev = [];
-    public array $variantsDev = [];
     public string $readmeProd = "";
+    public array $tagsDev = [];
     public array $tagsProd = [];
+    public array $variantsDev = [];
     public array $variantsProd = [];
 
     public function __construct(string $name)
@@ -34,5 +37,35 @@ class Image
             'variantsDev' => $this->variantsDev,
             'variantsProd' => $this->variantsProd
         ]);
+    }
+
+    public function getReadme(string $fallback): string
+    {
+        if ($this->readmeDev == "" or empty($this->readmeDev)) {
+            if ($this->readmeProd == "" or empty ($this->readmeProd)) {
+                return $fallback;
+            }
+            return $this->readmeProd;
+        }
+        return $this->readmeDev;
+    }
+
+    /**
+     * @throws NotFoundException
+     */
+    public static function loadFromDatafeed(string $datafeed): Image
+    {
+        $imageDatafeed = new JsonDataFeed();
+        $imageDatafeed->loadFile($datafeed);
+        $image = new Image($imageDatafeed->json['name']);
+
+        $image->tagsDev = $imageDatafeed->json['tagsDev'];
+        $image->tagsProd = $imageDatafeed->json['tagsProd'];
+        $image->readmeDev = $imageDatafeed->json['readmeDev'];
+        $image->readmeProd = $imageDatafeed->json['readmeProd'];
+        $image->variantsDev = $imageDatafeed->json['variantsDev'];
+        $image->variantsProd = $imageDatafeed->json['variantsProd'];
+
+        return $image;
     }
 }

--- a/app/Image.php
+++ b/app/Image.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App;
 
 use Autodocs\DataFeed\JsonDataFeed;
@@ -40,8 +42,8 @@ class Image
 
     public function getReadme(string $fallback): string
     {
-        if ($this->readmeDev == "" or empty($this->readmeDev)) {
-            if ($this->readmeProd == "" or empty ($this->readmeProd)) {
+        if ("" === $this->readmeDev || empty($this->readmeDev)) {
+            if ("" === $this->readmeProd || empty($this->readmeProd)) {
                 return $fallback;
             }
             return $this->readmeProd;

--- a/app/Image.php
+++ b/app/Image.php
@@ -4,6 +4,7 @@ namespace App;
 
 use Autodocs\DataFeed\JsonDataFeed;
 use Autodocs\Exception\NotFoundException;
+use Autodocs\Mark;
 
 class Image
 {
@@ -13,8 +14,7 @@ class Image
     public string $readmeProd = "";
     public array $tagsDev = [];
     public array $tagsProd = [];
-    public array $variantsDev = [];
-    public array $variantsProd = [];
+    public array $variants = [];
 
     public function __construct(string $name)
     {
@@ -34,8 +34,7 @@ class Image
             'tagsProd' => $this->tagsProd,
             'readmeDev' => $this->readmeDev,
             'readmeProd' => $this->readmeProd,
-            'variantsDev' => $this->variantsDev,
-            'variantsProd' => $this->variantsProd
+            'variants' => $this->variants,
         ]);
     }
 
@@ -48,6 +47,23 @@ class Image
             return $this->readmeProd;
         }
         return $this->readmeDev;
+    }
+
+    public function getRegistryTagsTable(): string
+    {
+        $tagsDev = $tagsProd = [];
+        foreach ($this->tagsDev as $tag) {
+            $tagsDev[] = $tag['name'];
+        }
+        foreach ($this->tagsProd as $tag) {
+            $tagsProd[] = $tag['name'];
+        }
+        $rows = [
+            ['`cgr.dev/chainguard`', count($tagsDev) ? implode(', ', $tagsDev) : "No public tags are available for this image."],
+            ['`cgr.dev/chainguard-private`', count($tagsProd) ? implode(', ', $tagsProd) : "No production tags are available for this image."]
+        ];
+
+        return Mark::table($rows, ['Registry', 'Tags']);
     }
 
     /**
@@ -63,8 +79,7 @@ class Image
         $image->tagsProd = $imageDatafeed->json['tagsProd'];
         $image->readmeDev = $imageDatafeed->json['readmeDev'];
         $image->readmeProd = $imageDatafeed->json['readmeProd'];
-        $image->variantsDev = $imageDatafeed->json['variantsDev'];
-        $image->variantsProd = $imageDatafeed->json['variantsProd'];
+        $image->variants = $imageDatafeed->json['variants'];
 
         return $image;
     }

--- a/app/Image.php
+++ b/app/Image.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App;
+
+class Image
+{
+    public string $name;
+
+    public string $readmeDev = "";
+    public array $tagsDev = [];
+    public array $variantsDev = [];
+    public string $readmeProd = "";
+    public array $tagsProd = [];
+    public array $variantsProd = [];
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getJson(): string
+    {
+        return json_encode([
+            'name' => $this->name,
+            'tagsDev' => $this->tagsDev,
+            'tagsProd' => $this->tagsProd,
+            'readmeDev' => $this->readmeDev,
+            'readmeProd' => $this->readmeProd,
+            'variantsDev' => $this->variantsDev,
+            'variantsProd' => $this->variantsProd
+        ]);
+    }
+}

--- a/app/ImageCollection.php
+++ b/app/ImageCollection.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App;
 
 class ImageCollection
@@ -33,7 +35,7 @@ class ImageCollection
         }
 
         if ($createNew) {
-             return new Image($imageName);
+            return new Image($imageName);
         }
 
         return null;

--- a/app/ImageCollection.php
+++ b/app/ImageCollection.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App;
+
+class ImageCollection
+{
+    protected array $images = [];
+
+    public function add(Image $image): void
+    {
+        $this->images[] = $image;
+    }
+
+    public function addImages(array $images): void
+    {
+        foreach ($images as $image) {
+            $this->add($image);
+        }
+    }
+
+    public function getImages(): array
+    {
+        return $this->images;
+    }
+
+    public function get(string $imageName, $createNew = false): ?Image
+    {
+        /** @var Image $image */
+        foreach ($this->images as $image) {
+            if ($image->getName() === $imageName) {
+                return $image;
+            }
+        }
+
+        if ($createNew) {
+             return new Image($imageName);
+        }
+
+        return null;
+    }
+}

--- a/app/Page/OverviewPage.php
+++ b/app/Page/OverviewPage.php
@@ -33,7 +33,7 @@ class OverviewPage extends ReferencePage
      */
     public function getContent(): string
     {
-        $image = Image::loadFromDatafeed($this->autodocs->config['cache_dir'] . '/datafeeds/' . $this->image . ".json");
+        $image = Image::loadFromDatafeed($this->autodocs->config['cache_dir'].'/datafeeds/'.$this->image.".json");
         $fallback = $this->autodocs->stencil->applyTemplate('image_overview_fallback', [
             'image' => $this->image
         ]);

--- a/app/Page/OverviewPage.php
+++ b/app/Page/OverviewPage.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Page;
 
+use App\Image;
+use Autodocs\Exception\NotFoundException;
 use Autodocs\Page\ReferencePage;
 use Minicli\FileNotFoundException;
 
@@ -14,35 +16,6 @@ class OverviewPage extends ReferencePage
     public function loadData(array $parameters = []): void
     {
         $this->image = $parameters['image'];
-    }
-
-    /**
-     * @throws FileNotFoundException
-     */
-    public function findReadme(string $image): string
-    {
-        $imagesList = $this->autodocs->getDataFeed($this->autodocs->config['cache_images_file']);
-        foreach ($imagesList->json as $imageInfo) {
-            if ($imageInfo['repo']['name'] === $image) {
-                if (array_key_exists('readme', $imageInfo['repo'])) {
-                    return $imageInfo['repo']['readme'];
-                }
-
-                //readme not defined, try to find from annotation
-                $imageMeta = $this->autodocs->getDataFeed("{$image}.latest.json");
-                $image_source = $imageMeta->json["predicate"]["annotations"]["org.opencontainers.image.source"];
-                $image_source = explode("/", $image_source);
-                $referenceImage = end($image_source);
-                if ($referenceImage !== $image) {
-                    $this->findReadme($referenceImage);
-                }
-            }
-        }
-
-        //no readme found, return fallback template
-        return $this->autodocs->stencil->applyTemplate('image_overview_fallback', [
-            'image' => $this->image
-        ]);
     }
 
     public function getName(): string
@@ -56,15 +29,19 @@ class OverviewPage extends ReferencePage
     }
 
     /**
-     * @throws FileNotFoundException
+     * @throws FileNotFoundException|NotFoundException
      */
     public function getContent(): string
     {
-        $readme = $this->findReadme($this->image);
+        $image = Image::loadFromDatafeed($this->autodocs->config['cache_dir'] . '/datafeeds/' . $this->image . ".json");
+        $fallback = $this->autodocs->stencil->applyTemplate('image_overview_fallback', [
+            'image' => $this->image
+        ]);
+        $readme = $image->getReadme($fallback);
 
         $readme = str_ireplace("# {$readme}", "", $readme);
         $readme = preg_replace('/<!--monopod:start-->(.*)<!--monopod:end-->/Uis', '', $readme);
-
+        
         return $this->autodocs->stencil->applyTemplate('image_overview', [
             'title' => $this->image,
             'content' => $readme

--- a/app/Page/OverviewPage.php
+++ b/app/Page/OverviewPage.php
@@ -41,7 +41,7 @@ class OverviewPage extends ReferencePage
 
         $readme = str_ireplace("# {$readme}", "", $readme);
         $readme = preg_replace('/<!--monopod:start-->(.*)<!--monopod:end-->/Uis', '', $readme);
-        
+
         return $this->autodocs->stencil->applyTemplate('image_overview', [
             'title' => $this->image,
             'content' => $readme

--- a/app/Page/ProvenancePage.php
+++ b/app/Page/ProvenancePage.php
@@ -33,7 +33,7 @@ class ProvenancePage extends ReferencePage
      */
     public function getContent(): string
     {
-        $image = Image::loadFromDatafeed($this->autodocs->config['cache_dir'] . '/datafeeds/' . $this->image . ".json");
+        $image = Image::loadFromDatafeed($this->autodocs->config['cache_dir'].'/datafeeds/'.$this->image.".json");
 
         return $this->autodocs->stencil->applyTemplate('image_provenance_page', [
             'title' => $this->image,

--- a/app/Page/ProvenancePage.php
+++ b/app/Page/ProvenancePage.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Page;
 
+use App\Image;
+use Autodocs\Exception\NotFoundException;
 use Autodocs\Page\ReferencePage;
 use Minicli\FileNotFoundException;
 
@@ -27,12 +29,16 @@ class ProvenancePage extends ReferencePage
 
     /**
      * @throws FileNotFoundException
+     * @throws NotFoundException
      */
     public function getContent(): string
     {
+        $image = Image::loadFromDatafeed($this->autodocs->config['cache_dir'] . '/datafeeds/' . $this->image . ".json");
+
         return $this->autodocs->stencil->applyTemplate('image_provenance_page', [
             'title' => $this->image,
-            'description' => "Provenance information for {$this->image} Chainguard Image"
+            'description' => "Provenance information for {$this->image} Chainguard Image",
+            'registryTags' => $image->getRegistryTagsTable()
         ]);
     }
 }

--- a/app/Page/TagsHistoryPage.php
+++ b/app/Page/TagsHistoryPage.php
@@ -41,8 +41,8 @@ class TagsHistoryPage extends ReferencePage
         return $this->autodocs->stencil->applyTemplate('image_tags_page', [
             'title' => $this->image,
             'description' => "Image Tags and History for the {$this->image} Chainguard Image",
-            'developer_tags' => count($image->tagsDev) ? $this->getTagsTable($image->tagsDev) : "This image doesn't have Developer versions currently available.",
-            'production_tags' => count($image->tagsProd) ? $this->getTagsTable($image->tagsProd) : "This image doesn't have Production versions currently available.",
+            'developer_tags' => count($image->tagsDev) ? $this->getTagsTable($image->tagsDev) : "Currently, there are no Developer versions of this image available.",
+            'production_tags' => count($image->tagsProd) ? $this->getTagsTable($image->tagsProd) : "Currently, there are no Production versions of this image available.",
         ]);
     }
 

--- a/app/Page/TagsHistoryPage.php
+++ b/app/Page/TagsHistoryPage.php
@@ -37,20 +37,12 @@ class TagsHistoryPage extends ReferencePage
     public function getContent(): string
     {
         $image = Image::loadFromDatafeed($this->autodocs->config['cache_dir'] . '/datafeeds/' . $this->image . ".json");
-        $content = "";
-
-        if (count($image->tagsDev)) {
-            $content = "## Development Tags\n\n";
-            $content .= $this->getTagsTable($image->tagsDev);
-        }
-
-        $content .= "\n## Production Tags\n\n";
-        $content .= $this->getTagsTable($image->tagsProd);
 
         return $this->autodocs->stencil->applyTemplate('image_tags_page', [
             'title' => $this->image,
             'description' => "Image Tags and History for the {$this->image} Chainguard Image",
-            'content' => $content,
+            'developer_tags' => count($image->tagsDev) ? $this->getTagsTable($image->tagsDev) : "This image doesn't have Developer versions currently available.",
+            'production_tags' => count($image->tagsProd) ? $this->getTagsTable($image->tagsProd) : "This image doesn't have Production versions currently available.",
         ]);
     }
 

--- a/app/Page/TagsHistoryPage.php
+++ b/app/Page/TagsHistoryPage.php
@@ -8,7 +8,6 @@ use App\Image;
 use Autodocs\Exception\NotFoundException;
 use Autodocs\Mark;
 use Autodocs\Page\ReferencePage;
-use Exception;
 use DateTime;
 use Minicli\FileNotFoundException;
 
@@ -36,7 +35,7 @@ class TagsHistoryPage extends ReferencePage
      */
     public function getContent(): string
     {
-        $image = Image::loadFromDatafeed($this->autodocs->config['cache_dir'] . '/datafeeds/' . $this->image . ".json");
+        $image = Image::loadFromDatafeed($this->autodocs->config['cache_dir'].'/datafeeds/'.$this->image.".json");
 
         return $this->autodocs->stencil->applyTemplate('image_tags_page', [
             'title' => $this->image,

--- a/app/Page/VariantsPage.php
+++ b/app/Page/VariantsPage.php
@@ -8,7 +8,6 @@ use App\Image;
 use Autodocs\Mark;
 use Autodocs\Page\ReferencePage;
 use Exception;
-use TypeError;
 
 class VariantsPage extends ReferencePage
 {
@@ -45,7 +44,7 @@ class VariantsPage extends ReferencePage
             'Has a shell?',
         ];
 
-        $image = Image::loadFromDatafeed($this->autodocs->config['cache_dir'] . '/datafeeds/' . $this->image . ".json");
+        $image = Image::loadFromDatafeed($this->autodocs->config['cache_dir'].'/datafeeds/'.$this->image.".json");
         $packages = [];
 
         foreach ($image->variants as $variantName => $attestation) {

--- a/app/Page/VariantsPage.php
+++ b/app/Page/VariantsPage.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Page;
 
-use Autodocs\DataFeed\JsonDataFeed;
+use App\Image;
 use Autodocs\Mark;
 use Autodocs\Page\ReferencePage;
 use Exception;
@@ -13,22 +13,6 @@ use TypeError;
 class VariantsPage extends ReferencePage
 {
     public string $image;
-
-    public static array $allowedTags = [
-        'latest',
-        'latest-dev',
-        'latest-debug',
-        'latest-fpm',
-        'latest-fpm-dev',
-        'latest-glibc',
-        'latest-glibc-dev',
-        'latest-musl',
-        'latest-musl-dev',
-        'latest-root',
-        'latest-root-dev',
-        'latest-nonroot',
-        'latest-nonroot-dev'
-    ];
 
     public function loadData(array $parameters = []): void
     {
@@ -43,26 +27,6 @@ class VariantsPage extends ReferencePage
     public function getSavePath(): string
     {
         return $this->image.'/image_specs.md';
-    }
-
-    public function getImageVariants(): array
-    {
-        $variantsList = [];
-        $dataFeeds = $this->autodocs->dataFeeds;
-        /** @var JsonDataFeed $dataFeed */
-        foreach ($dataFeeds as $name => $dataFeed) {
-            if (str_starts_with($name, $this->image.'.latest')) {
-                list($imageName, $variantName, $extension) = explode('.', $name);
-                try {
-                    $dataFeed->loadFile($this->autodocs->config['cache_dir'].'/'.$name);
-                    $variantsList[$variantName] = $dataFeed;
-                } catch (TypeError $e) {
-                    //json might have issues. skip
-                }
-            }
-        }
-
-        return $variantsList;
     }
 
     /**
@@ -81,17 +45,13 @@ class VariantsPage extends ReferencePage
             'Has a shell?',
         ];
 
-
-        $variants = $this->getImageVariants();
+        $image = Image::loadFromDatafeed($this->autodocs->config['cache_dir'] . '/datafeeds/' . $this->image . ".json");
         $packages = [];
-        /** @var JsonDataFeed $variantFeed */
-        foreach ($variants as $variant => $variantFeed) {
-            if (empty($variantFeed->json) || ! key_exists('predicate', $variantFeed->json)) {
-                continue;
-            }
 
-            $config = $variantFeed->json['predicate'];
-            $headers[] = $variant;
+        foreach ($image->variants as $variantName => $attestation) {
+
+            $headers[] = $variantName;
+            $config = $attestation['predicate'];
             $columns[] = [
                 $this->getDefaultUser($config),
                 $this->getEntrypoint($config),
@@ -104,16 +64,16 @@ class VariantsPage extends ReferencePage
             //build packages array
             foreach ($config['contents']['packages'] as $dep) {
                 $split = explode("=", $dep);
-                $packages[$split[0]][] = $variant;
+                $packages[$split[0]][] = $variantName;
             }
         }
 
-        $content .= $this->getVariantsSection($this->image, $variants, $columns, $headers);
+        $content .= $this->getVariantsSection($this->image, $image->variants, $columns, $headers);
         $content .= "\n".$this->getDependenciesSection($packages, $headers);
 
         return $this->autodocs->stencil->applyTemplate('image_specs_page', [
             'title' => $this->image,
-            'description' => "Detailed information about the public {$this->image} Chainguard Image variants",
+            'description' => "Detailed information about the public {$this->image} Chainguard Image.",
             'content' => $content,
         ]);
     }
@@ -186,20 +146,7 @@ class VariantsPage extends ReferencePage
 
     public function getVariantsSection(string $image, array $variants, array $columns, array $headers): string
     {
-        $content = "## Variants Compared\n";
-
-        //check variants
-        $number = (1 === sizeof($variants)) ? "one public variant" : sizeof($variants)." public variants";
-
-        $content .= sprintf(
-            "The **%s** Chainguard Image currently has %s: %s",
-            $image,
-            $number,
-            "\n\n- `".implode("`\n- `", array_keys($variants))."`\n\n"
-        );
-
-        $content .= "The table has detailed information about each of these variants.\n\n";
-
+        $content = "";
         $tableRows = [];
         for ($i = 0; $i < sizeof($columns[0]); $i++) {
             $row = [];

--- a/bin/getImages.sh
+++ b/bin/getImages.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env sh
 
 export OUTPUT_PATH=workdir/cache
-
-echo "Getting images tags list...";
-chainctl img ls -ojson > ${OUTPUT_PATH}/images-tags.json 2>&1
+export GROUP_PUBLIC=720909c9f5279097d847ad02a2f24ba8f59de36a
+export GROUP_PRIVATE=ce2d1984a010471142503340d670612d63ffb9f6
+echo "Fetching developer images list...";
+chainctl img ls -ojson --group=$GROUP_PUBLIC > ${OUTPUT_PATH}/images-tags-dev.json 2>&1
+echo "Fetching production images list...";
+chainctl img ls -ojson --group=$GROUP_PRIVATE > ${OUTPUT_PATH}/images-tags-prod.json 2>&1
 echo "Finished.";

--- a/bin/getVariants.sh
+++ b/bin/getVariants.sh
@@ -2,14 +2,28 @@
 
 export OUTPUT_PATH=workdir/cache
 
-echo "Fetching variants config...";
-for image in $(jq -r '.[].repo.name' ${OUTPUT_PATH}/images-tags.json); do
-  echo '\n#######################################################\n'
-  echo "Fetching latest tags info for ${image} image"
-  for tags in $(jq --arg image_repo $image -r 'map(select(.repo.name == $image_repo)) | [.[].tags[].name] | map(select(startswith("latest"))) | .[]' ${OUTPUT_PATH}/images-tags.json); do
+echo "Fetching image variants: Developer Images";
+for image in $(jq -r '.[].repo.name' ${OUTPUT_PATH}/images-tags-dev.json); do
+  echo '#######################################################'
+  echo "Fetching config and variants info for ${image} image"
+  for tags in $(jq --arg image_repo "$image" -r 'map(select(.repo.name == $image_repo)) | [.[].tags[].name] | map(select(startswith("latest"))) | .[]' ${OUTPUT_PATH}/images-tags-dev.json); do
     for tag in $tags; do
-      cosign download attestation --platform=linux/amd64 --predicate-type=https://apko.dev/image-configuration \
-      cgr.dev/chainguard/${image}:${tag} 2>/dev/null | jq -r '.payload' | base64 -d > ${OUTPUT_PATH}/${image}.${tag}.json
+      PAYLOAD=$(cosign download attestation --platform=linux/amd64 --predicate-type=https://apko.dev/image-configuration \
+      cgr.dev/chainguard/"${image}":"${tag}" 2>/dev/null | jq -r '.payload' | base64 -d)
+      echo "$PAYLOAD" > ${OUTPUT_PATH}/images-dev/"${image}"."${tag}".json
+    done
+  done
+done
+
+echo "Fetching image variants: Production Images";
+for image in $(jq -r '.[].repo.name' ${OUTPUT_PATH}/images-tags-prod.json); do
+  echo '#######################################################'
+  echo "Fetching config and variants info for ${image} image"
+  for tags in $(jq --arg image_repo "$image" -r 'map(select(.repo.name == $image_repo)) | [.[].tags[].name] | map(select(startswith("latest"))) | .[]' ${OUTPUT_PATH}/images-tags-prod.json); do
+    for tag in $tags; do
+      PAYLOAD=$(cosign download attestation --platform=linux/amd64 --predicate-type=https://apko.dev/image-configuration \
+      cgr.dev/chainguard-private/"${image}":"${tag}" 2>/dev/null | jq -r '.payload' | base64 -d)
+      echo "$PAYLOAD" > ${OUTPUT_PATH}/images-prod/"${image}"."${tag}".json
     done
   done
 done

--- a/bin/getVariants.sh
+++ b/bin/getVariants.sh
@@ -2,19 +2,6 @@
 
 export OUTPUT_PATH=workdir/cache
 
-echo "Fetching image variants: Developer Images";
-for image in $(jq -r '.[].repo.name' ${OUTPUT_PATH}/images-tags-dev.json); do
-  echo '#######################################################'
-  echo "Fetching config and variants info for ${image} image"
-  for tags in $(jq --arg image_repo "$image" -r 'map(select(.repo.name == $image_repo)) | [.[].tags[].name] | map(select(startswith("latest"))) | .[]' ${OUTPUT_PATH}/images-tags-dev.json); do
-    for tag in $tags; do
-      PAYLOAD=$(cosign download attestation --platform=linux/amd64 --predicate-type=https://apko.dev/image-configuration \
-      cgr.dev/chainguard/"${image}":"${tag}" 2>/dev/null | jq -r '.payload' | base64 -d)
-      echo "$PAYLOAD" > ${OUTPUT_PATH}/images-dev/"${image}"."${tag}".json
-    done
-  done
-done
-
 echo "Fetching image variants: Production Images";
 for image in $(jq -r '.[].repo.name' ${OUTPUT_PATH}/images-tags-prod.json); do
   echo '#######################################################'

--- a/templates/image_overview.tpl
+++ b/templates/image_overview.tpl
@@ -18,7 +18,7 @@ toc: true
 
 {{< tabs >}}
 {{< tab title="Overview" active=true url="/chainguard/chainguard-images/reference/{{ title }}/" >}}
-{{< tab title="Variants" active=false url="/chainguard/chainguard-images/reference/{{ title }}/image_specs/" >}}
+{{< tab title="Details" active=false url="/chainguard/chainguard-images/reference/{{ title }}/image_specs/" >}}
 {{< tab title="Tags History" active=false url="/chainguard/chainguard-images/reference/{{ title }}/tags_history/" >}}
 {{< tab title="Provenance" active=false url="/chainguard/chainguard-images/reference/{{ title }}/provenance_info/" >}}
 {{</ tabs >}}

--- a/templates/image_overview_fallback.tpl
+++ b/templates/image_overview_fallback.tpl
@@ -1,6 +1,6 @@
 Minimal **{{ image }}** images with nightly builds.
 
-## Get it!
+## Download this Image
 
 ```
 docker pull cgr.dev/chainguard/{{ image }}:latest

--- a/templates/image_provenance_page.tpl
+++ b/templates/image_provenance_page.tpl
@@ -19,12 +19,26 @@ toc: true
 {{< tab title="Provenance" active=true url="/chainguard/chainguard-images/reference/{{ title }}/provenance_info/" >}}
 {{</ tabs >}}
 
-All Chainguard Images contain verifiable signatures and high-quality SBOMs (software bill of materials), features that enable users to confirm the origin of each image built and have a detailed list of everything that is packed within.
+All Chainguard Images contain verifiable signatures and high-quality SBOMs (software bill of materials), features that enable users to confirm the origin of each image build and have a detailed list of everything that is packed within.
+
+You'll need [cosign](https://docs.sigstore.dev/cosign/overview/) and [jq](https://stedolan.github.io/jq/) in order to download and verify image attestations.
+
+### Registry and Tags for {{ title }} Image
+Attestations are provided per image build, so you'll need to specify the correct tag and registry when pulling attestations from an image with `cosign`.
+
+{{ registryTags }}
+
+- `cgr.dev/chainguard` - the Public Registry contains our **Developer Images**, which typically comprise the `latest*` versions of an image.
+- `cgr.dev/chainguard-private` - the Private/Dedicated Registry contains our **[Production Images](https://www.chainguard.dev/chainguard-images)**, which include all versioned tags of an image and special images that are not available in the public registry (including FIPS images and other custom builds).
+
+The commands listed on this page will default to the `latest` tag, but you can specify a different tag to fetch attestations for.
 
 ## Verifying {{ title }} Image Signatures
 The **{{ title }}** Chainguard Images are signed using Sigstore, and you can check the included signatures using `cosign`.
 
-The following command requires [cosign](https://docs.sigstore.dev/cosign/overview/) and [jq](https://stedolan.github.io/jq/) to be installed on your machine. It will pull detailed information about all signatures found for the provided image.
+The `cosign verify` command will pull detailed information about all signatures found for the provided image.
+
+### Public Registry
 
 ```shell
 cosign verify \
@@ -33,7 +47,14 @@ cosign verify \
   cgr.dev/chainguard/{{ title }} | jq
 ```
 
-By default, this command will fetch signatures for the `latest` tag. You can also specify the tag you want to fetch signatures for.
+### Private/Dedicated Registry
+
+```shell
+cosign verify \
+--certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+--certificate-identity=https://github.com/chainguard-images/images-private/.github/workflows/release.yaml@refs/heads/main \
+cgr.dev/chainguard-private/{{ title }} | jq
+```
 
 ## Downloading {{ title }} Image Attestations
 
@@ -48,12 +69,24 @@ The following [attestations](https://slsa.dev/attestation-model) for the {{ titl
 
 To download an attestation, use the `cosign download attestation` command and provide both the predicate type and the build platform. For example, the following command will obtain the SBOM for the {{ title }} image on `linux/amd64`:
 
+### Public Registry
+
 ```shell
 cosign download attestation \
   --platform=linux/amd64 \
   --predicate-type=https://spdx.dev/Document \
   cgr.dev/chainguard/{{ title }} | jq -r .payload | base64 -d | jq .predicate
 ```
+
+### Private/Dedicated Registry
+
+```shell
+cosign download attestation \
+--platform=linux/amd64 \
+--predicate-type=https://spdx.dev/Document \
+cgr.dev/chainguard-private/{{ title }} | jq -r .payload | base64 -d | jq .predicate
+```
+
 By default, this command will fetch the SBOM assigned to the `latest` tag. You can also specify the tag you want to fetch the attestation from.
 
 To download a different attestation, replace the `--predicate-type` parameter value with the desired attestation URL identifier.
@@ -61,12 +94,24 @@ To download a different attestation, replace the `--predicate-type` parameter va
 ## Verifying {{ title }} Image Attestations
 You can use the `cosign verify-attestation` command to check the signatures of the {{ title }} image attestations:
 
+### Public Registry
+
 ```shell
 cosign verify-attestation \
   --type https://spdx.dev/Document \
   --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
   --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main \
   cgr.dev/chainguard/{{ title }}
+```
+
+### Private/Dedicated Registry
+
+```shell
+cosign verify-attestation \
+--type https://spdx.dev/Document \
+--certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+--certificate-identity=https://github.com/chainguard-images/images-private/.github/workflows/release.yaml@refs/heads/main \
+cgr.dev/chainguard-private/{{ title }}
 ```
 
 This will pull in the signature for the attestation specified by the `--type` parameter, which in this case is the SPDX attestation. You should get output that verifies the SBOM attestation signature in cosign's transparency log:

--- a/templates/image_provenance_page.tpl
+++ b/templates/image_provenance_page.tpl
@@ -14,7 +14,7 @@ toc: true
 
 {{< tabs >}}
 {{< tab title="Overview" active=false url="/chainguard/chainguard-images/reference/{{ title }}/" >}}
-{{< tab title="Variants" active=false url="/chainguard/chainguard-images/reference/{{ title }}/image_specs/" >}}
+{{< tab title="Details" active=false url="/chainguard/chainguard-images/reference/{{ title }}/image_specs/" >}}
 {{< tab title="Tags History" active=false url="/chainguard/chainguard-images/reference/{{ title }}/tags_history/" >}}
 {{< tab title="Provenance" active=true url="/chainguard/chainguard-images/reference/{{ title }}/provenance_info/" >}}
 {{</ tabs >}}
@@ -29,7 +29,7 @@ Attestations are provided per image build, so you'll need to specify the correct
 {{ registryTags }}
 
 - `cgr.dev/chainguard` - the Public Registry contains our **Developer Images**, which typically comprise the `latest*` versions of an image.
-- `cgr.dev/chainguard-private` - the Private/Dedicated Registry contains our **[Production Images](https://www.chainguard.dev/chainguard-images)**, which include all versioned tags of an image and special images that are not available in the public registry (including FIPS images and other custom builds).
+- `cgr.dev/chainguard-private` - the Private/Dedicated Registry contains our **Production Images**, which include all versioned tags of an image and special images that are not available in the public registry (including FIPS images and other custom builds).
 
 The commands listed on this page will default to the `latest` tag, but you can specify a different tag to fetch attestations for.
 
@@ -114,7 +114,7 @@ cosign verify-attestation \
 cgr.dev/chainguard-private/{{ title }}
 ```
 
-This will pull in the signature for the attestation specified by the `--type` parameter, which in this case is the SPDX attestation. You should get output that verifies the SBOM attestation signature in cosign's transparency log:
+This will pull in the signature for the attestation specified by the `--type` parameter, which in this case is the SPDX attestation. You will receive output that verifies the SBOM attestation signature in cosign's transparency log:
 
 ```
 Verification for cgr.dev/chainguard/{{ title }} --

--- a/templates/image_specs_page.tpl
+++ b/templates/image_specs_page.tpl
@@ -1,5 +1,5 @@
 ---
-title: "{{ title }} Image Variants"
+title: "{{ title }} Image Details"
 type: "article"
 unlisted: true
 description: "{{ description }}"
@@ -14,11 +14,11 @@ toc: true
 
 {{< tabs >}}
 {{< tab title="Overview" active=false url="/chainguard/chainguard-images/reference/{{ title }}/" >}}
-{{< tab title="Variants" active=true url="/chainguard/chainguard-images/reference/{{ title }}/image_specs/" >}}
+{{< tab title="Details" active=true url="/chainguard/chainguard-images/reference/{{ title }}/image_specs/" >}}
 {{< tab title="Tags History" active=false url="/chainguard/chainguard-images/reference/{{ title }}/tags_history/" >}}
 {{< tab title="Provenance" active=false url="/chainguard/chainguard-images/reference/{{ title }}/provenance_info/" >}}
 {{</ tabs >}}
 
-This page shows detailed information about all public variants of the Chainguard **{{ title }}** Image.
+This page shows detailed information about the Chainguard **{{ title }}** Image.
 
 {{ content }}

--- a/templates/image_tags_page.tpl
+++ b/templates/image_tags_page.tpl
@@ -14,7 +14,7 @@ toc: true
 
 {{< tabs >}}
 {{< tab title="Overview" active=false url="/chainguard/chainguard-images/reference/{{ title }}/" >}}
-{{< tab title="Variants" active=false url="/chainguard/chainguard-images/reference/{{ title }}/image_specs/" >}}
+{{< tab title="Details" active=false url="/chainguard/chainguard-images/reference/{{ title }}/image_specs/" >}}
 {{< tab title="Tags History" active=true url="/chainguard/chainguard-images/reference/{{ title }}/tags_history/" >}}
 {{< tab title="Provenance" active=false url="/chainguard/chainguard-images/reference/{{ title }}/provenance_info/" >}}
 {{</ tabs >}}
@@ -29,6 +29,6 @@ The Public Registry contains our **Developer Images**, which typically comprise 
 {{ developer_tags }}
 
 ### Private/Dedicated Registry
-The Private/Dedicated Registry contains our **[Production Images](https://www.chainguard.dev/chainguard-images)**, which include all versioned tags of an image and special images that are not available in the public registry (including FIPS images and other custom builds).
+The Private/Dedicated Registry contains our **Production Images**, which include all versioned tags of an image and special images that are not available in the public registry (including FIPS images and other custom builds).
 
 {{ production_tags }}

--- a/templates/image_tags_page.tpl
+++ b/templates/image_tags_page.tpl
@@ -19,8 +19,16 @@ toc: true
 {{< tab title="Provenance" active=false url="/chainguard/chainguard-images/reference/{{ title }}/provenance_info/" >}}
 {{</ tabs >}}
 
-The following table contains the most recent tags and digests that can be used to pin your Dockerfile to a specific build of this image. Check our guide on [Using the Tag History API](/chainguard/chainguard-images/using-the-tag-history-api/) for information on how to fetch all tags from an image and how to pin your Dockerfile to a specific digest.
+The following tables contains the most recent tags and digests that can be used to pin your Dockerfile to a specific build of this image. Check our guide on [Using the Tag History API](/chainguard/chainguard-images/using-the-tag-history-api/) for information on how to fetch all tags from an image and how to pin your Dockerfile to a specific digest.
 
 Please note that digests and timestamps only change when there is a change to the image, even though images are rebuilt every night. The "Last Changed" column indicates when the image was last modified, and doesn't always reflect the latest build timestamp. For more information about how our reproducible builds work, please refer to [this blog post](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds).
 
-{{ content }}
+### Public Registry
+The Public Registry contains our **Developer Images**, which typically comprise the `latest*` versions of an image.
+
+{{ developer_tags }}
+
+### Private/Dedicated Registry
+The Private/Dedicated Registry contains our **[Production Images](https://www.chainguard.dev/chainguard-images)**, which include all versioned tags of an image and special images that are not available in the public registry (including FIPS images and other custom builds).
+
+{{ production_tags }}


### PR DESCRIPTION
This PR brings Production Images to Autodocs. We now parse cached metadata from cosign queries and combine all info in a single Datafeed per image, which greatly facilitates working with the data later on to build pages.

Once this is merged and a new release is made, I will open a new PR with an update to the current workflow.