### PR TITLE
Adding images to ignore list

### DIFF
--- a/.github/workflows/autodocs-images.yaml
+++ b/.github/workflows/autodocs-images.yaml
@@ -13,7 +13,7 @@ env:
   AUTODOCS_CHANGELOG: "${{ github.workspace }}/edu/content/chainguard/chainguard-images/reference"
   AUTODOCS_CHANGELOG_OUTPUT: "${{ github.workspace }}/changelog.md"
   AUTODOCS_CHANGELOG_FILE: "${{ github.workspace }}/edu/autodocs/changelog.md"
-  AUTODOCS_IGNORE_IMAGES: "scanner-test:alpine-base:k3s-images:k3s-embedded:source-controller:sdk:spire:musl-dynamic:nri-kube-events:nri-kubernetes:nri-prometheus:gcc-musl:external-attacher:external-resizer:oidc-discovery-provider:kubernetes-dashboard-metrics-scraper:kustomize-controller:kyvernopre:alpine-base:curl-dev"
+  AUTODOCS_IGNORE_IMAGES: "minio-fips-client:scanner-test:alpine-base:k3s-images:k3s-embedded:source-controller:sdk:spire:musl-dynamic:nri-kube-events:nri-kubernetes:nri-prometheus:gcc-musl:external-attacher:external-resizer:oidc-discovery-provider:kubernetes-dashboard-metrics-scraper:kustomize-controller:kyvernopre:alpine-base:curl-dev"
 
 jobs:
   main:
@@ -89,7 +89,7 @@ jobs:
       # Build Json Datafeeds
       ############################################################################################
       - name: Build Image Datafeeds
-        uses: chainguard-dev/images-autodocs@1.4.0
+        uses: chainguard-dev/images-autodocs@1.4.1
         with:
           command: build datafeeds
 
@@ -97,7 +97,7 @@ jobs:
       # Generate Docs
       ############################################################################################
       - name: Update the reference docs for Chainguard Images
-        uses: chainguard-dev/images-autodocs@1.4.0
+        uses: chainguard-dev/images-autodocs@1.4.1
         with:
           command: build images
 
@@ -152,7 +152,7 @@ jobs:
       ############################################################################################
       - name: "Send notification to Slack"
         if: ${{ steps.cpr.outputs.pull-request-number }}
-        uses: chainguard-dev/images-autodocs@1.4.0
+        uses: chainguard-dev/images-autodocs@1.4.1
         with:
           command: notify pullrequest
         env:

--- a/.github/workflows/update-data-sources.yaml
+++ b/.github/workflows/update-data-sources.yaml
@@ -1,0 +1,81 @@
+name: Build Chainguard Images Reference Docs
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+  workflow_dispatch:
+
+env:
+  AUTODOCS_CACHE: "${{ github.workspace }}/cache"
+  AUTODOCS_IGNORE_IMAGES: "alpine-base:k3s-images:k3s-embedded:source-controller:sdk:spire:musl-dynamic:nri-kube-events:nri-kubernetes:nri-prometheus:gcc-musl:external-attacher:external-resizer:oidc-discovery-provider:kubernetes-dashboard-metrics-scraper:kustomize-controller:kyvernopre:alpine-base:curl-dev"
+jobs:
+  main:
+    permissions:
+      id-token: write # Enable OIDC
+      pull-requests: write
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      ############################################################################################
+      # Set up Build Environment
+      ############################################################################################
+      - name: Set up workdir
+        run: |
+          mkdir -m 777 -p "${{ env.AUTODOCS_CACHE }}"
+
+      - name: Set up gitsign
+        uses: chainguard-dev/actions/setup-gitsign@main
+
+      - name: Set up Chainctl
+        uses: chainguard-dev/actions/setup-chainctl@main
+        with:
+          identity: "${{ secrets.CHAINCTL_IDENTITY }}"
+
+      - name: Set up Crane
+        uses: imjasonh/setup-crane@v0.1
+
+      - name: Set up Cosign
+        uses: sigstore/cosign-installer@v3.1.1
+
+      ############################################################################################
+      # Fetch Image Metadata
+      ############################################################################################
+      - name: Fetch images list
+        run: |
+          chainctl img ls --group "${{ secrets.CHAINCTL_GROUP_PUBLIC }}" -ojson > "${{ env.AUTODOCS_CACHE }}/images-tags.json"
+
+      - name: Fetch images metadata
+        run: |
+          echo "Fetching variants config...";
+          for image in $(jq -r '.[].repo.name' ${{ env.AUTODOCS_CACHE }}/images-tags.json); do
+            echo "\n###########################################################################\n"
+            echo "Fetching latest tags info for ${image} image"
+            echo "\n###########################################################################\n"
+            for tags in $(jq --arg image_repo $image -r 'map(select(.repo.name == $image_repo)) | [.[].tags[].name] | map(select(startswith("latest"))) | .[]' ${{ env.AUTODOCS_CACHE }}/images-tags.json); do
+              for tag in $tags; do
+                cosign verify-attestation $(crane digest --full-ref --platform=linux/amd64 cgr.dev/chainguard/${image}:${tag}) \
+                  --certificate-identity="https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main" \
+                  --certificate-oidc-issuer="https://token.actions.githubusercontent.com" --type="https://apko.dev/image-configuration" \
+                  2>/dev/null | jq -rs '.[0].payload' | base64 -d > ${{ env.AUTODOCS_CACHE }}/${image}.${tag}.json
+              done
+            done
+          done
+
+
+      ############################################################################################
+      # Notify Slack
+      ############################################################################################
+      - name: "Send notification to Slack"
+        if: ${{ steps.cpr.outputs.pull-request-number }}
+        uses: chainguard-dev/images-autodocs@1.3.3
+        with:
+          command: notify pullrequest
+        env:
+          AUTODOCS_SLACK_PRIMARY: ${{ secrets.AUTODOCS_SLACK_PRIMARY }}
+          AUTODOCS_SLACK_SECONDARY: ${{ secrets.AUTODOCS_SLACK_SECONDARY }}
+          AUTODOCS_SLACK_GENERAL: ${{ secrets.AUTODOCS_SLACK_GENERAL }}
+          PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
+          PR_ACTION: ${{ steps.cpr.outputs.pull-request-operation }}
+          PR_URL: ${{ steps.cpr.outputs.pull-request-url }}
+          PR_SHA: ${{ steps.cpr.outputs.pull-request-head-sha }}

--- a/app/Command/Build/ImagesController.php
+++ b/app/Command/Build/ImagesController.php
@@ -10,8 +10,6 @@ use Autodocs\DataFeed\JsonDataFeed;
 use Autodocs\Exception\NotFoundException;
 use autodocs\Service\AutodocsService;
 use Minicli\Command\CommandController;
-use Exception;
-use TypeError;
 
 class ImagesController extends CommandController
 {
@@ -60,7 +58,7 @@ class ImagesController extends CommandController
     private function buildDocsForImage(string $imageName): void
     {
         $autodocs = $this->getApp()->autodocs;
-        if (in_array($imageName, $autodocs->config['ignore_images']) OR str_starts_with($imageName, "request-")) {
+        if (in_array($imageName, $autodocs->config['ignore_images']) || str_starts_with($imageName, "request-")) {
             $this->out("\nSkipping image in ignore list: {$imageName}...\n");
             return;
         }

--- a/app/Command/Build/ImagesController.php
+++ b/app/Command/Build/ImagesController.php
@@ -26,18 +26,6 @@ class ImagesController extends CommandController
         $changelog = new ImageChangelog($autodocs->config['output']);
         $changelog->capture();
 
-        /*
-        try {
-            $imagesList = $autodocs->getDataFeed($autodocs->config['cache_images_file']);
-        } catch (Exception $exception) {
-            $this->error("Error: ".$exception->getMessage());
-            return;
-        } catch (TypeError $error) {
-            $this->error("Error: ".$error->getMessage());
-            return;
-        }*/
-
-
         if ($this->hasParam('image')) {
             $this->buildDocsForImage($this->getParam('image'));
         } else {
@@ -72,7 +60,7 @@ class ImagesController extends CommandController
     private function buildDocsForImage(string $imageName): void
     {
         $autodocs = $this->getApp()->autodocs;
-        if (in_array($imageName, $autodocs->config['ignore_images'])) {
+        if (in_array($imageName, $autodocs->config['ignore_images']) OR str_starts_with($imageName, "request-")) {
             $this->out("\nSkipping image in ignore list: {$imageName}...\n");
             return;
         }

--- a/config/autodocs.php
+++ b/config/autodocs.php
@@ -27,7 +27,7 @@ return [
         // String containing list of images to skip building docs for, separated by a colon
         'ignore_images' => config_unfurl(
             'AUTODOCS_IGNORE_IMAGES',
-            'alpine-base:k3s-images:k3s-embedded:sdk:spire:musl-dynamic:nri-kube-events:nri-kubernetes:nri-prometheus:gcc-musl:source-controller:curl-dev:alpine-base'
+            'alpine-base:k3s-images:k3s-embedded:sdk:spire:musl-dynamic:nri-kube-events:nri-kubernetes:nri-prometheus:gcc-musl:source-controller:curl-dev:minio-fips-client'
         ),
         // Original files that should be used as base for changelog comparison
         'changelog' => envconfig('AUTODOCS_CHANGELOG', __DIR__.'/../workdir/original'),


### PR DESCRIPTION
This PR adds logic to ignore images that start with `request-` and adds `minio-fips-client` to ignore list. It also updates the workflow so we don't need to create a separate PR for that.